### PR TITLE
Volatility

### DIFF
--- a/WebUI/YieldView.web/src/app/Modules/SP500PriceWithVolatility.ts
+++ b/WebUI/YieldView.web/src/app/Modules/SP500PriceWithVolatility.ts
@@ -2,4 +2,5 @@ export interface SP500PriceWithVolatility {
   date: string;       
   close: number;      
   volatility: number; 
+  isLocalShadowPoint: boolean;
 }

--- a/WebUI/YieldView.web/src/app/Modules/SP500PriceWithVolatility.ts
+++ b/WebUI/YieldView.web/src/app/Modules/SP500PriceWithVolatility.ts
@@ -2,5 +2,4 @@ export interface SP500PriceWithVolatility {
   date: string;       
   close: number;      
   volatility: number; 
-  isLocalShadowPoint: boolean;
 }

--- a/WebUI/YieldView.web/src/app/Modules/SP500PriceWithVolatility.ts
+++ b/WebUI/YieldView.web/src/app/Modules/SP500PriceWithVolatility.ts
@@ -1,0 +1,5 @@
+export interface SP500PriceWithVolatility {
+  date: string;       
+  close: number;      
+  volatility: number; 
+}

--- a/WebUI/YieldView.web/src/app/services/sp500.service.ts
+++ b/WebUI/YieldView.web/src/app/services/sp500.service.ts
@@ -16,9 +16,9 @@ export class SP500Service {
   return this.http.get<SP500Price[]>(`${this.baseUrl}?from=${from}&to=${to}`);
 }
 
-getPricesWithVolatility(from: string, to: string, volatilityWindowSize: number) {
+getPricesWithVolatility(from: string, to: string, volatilityWindowSize: number, eps: number) {
   return this.http.get<SP500PriceWithVolatility[]>(
-    `${this.baseUrl}/volatility?from=${from}&to=${to}&dataInterval=${volatilityWindowSize}`
+    `${this.baseUrl}/volatility?from=${from}&to=${to}&dataInterval=${volatilityWindowSize}&eps=${eps}`
   );
 }
 

--- a/WebUI/YieldView.web/src/app/services/sp500.service.ts
+++ b/WebUI/YieldView.web/src/app/services/sp500.service.ts
@@ -16,9 +16,9 @@ export class SP500Service {
   return this.http.get<SP500Price[]>(`${this.baseUrl}?from=${from}&to=${to}`);
 }
 
-getPricesWithVolatility(from: string, to: string, volatilityWindowSize: number, eps: number) {
+getPricesWithVolatility(from: string, to: string, volatilityWindowSize: number) {
   return this.http.get<SP500PriceWithVolatility[]>(
-    `${this.baseUrl}/volatility?from=${from}&to=${to}&dataInterval=${volatilityWindowSize}&eps=${eps}`
+    `${this.baseUrl}/volatility?from=${from}&to=${to}&dataInterval=${volatilityWindowSize}`
   );
 }
 

--- a/WebUI/YieldView.web/src/app/services/sp500.service.ts
+++ b/WebUI/YieldView.web/src/app/services/sp500.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { SP500Price } from '../Modules/SP500Price';
+import { SP500PriceWithVolatility } from '../Modules/SP500PriceWithVolatility';
 
 @Injectable({
   providedIn: 'root'
@@ -14,4 +15,11 @@ export class SP500Service {
   getPrices(from: string, to: string): Observable<SP500Price[]> {
   return this.http.get<SP500Price[]>(`${this.baseUrl}?from=${from}&to=${to}`);
 }
+
+getPricesWithVolatility(from: string, to: string, volatilityWindowSize: number) {
+  return this.http.get<SP500PriceWithVolatility[]>(
+    `${this.baseUrl}/volatility?from=${from}&to=${to}&dataInterval=${volatilityWindowSize}`
+  );
+}
+
 }

--- a/WebUI/YieldView.web/src/app/yield-curve-chart/yield-curve-chart.component.html
+++ b/WebUI/YieldView.web/src/app/yield-curve-chart/yield-curve-chart.component.html
@@ -100,16 +100,6 @@
           class="border rounded-lg px-3 py-2 w-full focus:outline-none focus:ring-2 focus:ring-green-500"
         />
       </div>
-       <div>
-        <label class="block text-sm font-medium text-gray-600 mb-1">eps</label>
-        <input
-          type="number"
-          step="0.1"
-          [value]="eps"
-          (change)="onEpsChange($event)"
-          class="border rounded-lg px-3 py-2 w-full focus:outline-none focus:ring-2 focus:ring-green-500"
-        />
-      </div>
     </div>
   </div>
 </div>

--- a/WebUI/YieldView.web/src/app/yield-curve-chart/yield-curve-chart.component.html
+++ b/WebUI/YieldView.web/src/app/yield-curve-chart/yield-curve-chart.component.html
@@ -100,6 +100,16 @@
           class="border rounded-lg px-3 py-2 w-full focus:outline-none focus:ring-2 focus:ring-green-500"
         />
       </div>
+       <div>
+        <label class="block text-sm font-medium text-gray-600 mb-1">eps</label>
+        <input
+          type="number"
+          step="0.1"
+          [value]="eps"
+          (change)="onEpsChange($event)"
+          class="border rounded-lg px-3 py-2 w-full focus:outline-none focus:ring-2 focus:ring-green-500"
+        />
+      </div>
     </div>
   </div>
 </div>

--- a/WebUI/YieldView.web/src/app/yield-curve-chart/yield-curve-chart.component.html
+++ b/WebUI/YieldView.web/src/app/yield-curve-chart/yield-curve-chart.component.html
@@ -18,8 +18,8 @@
             class="px-3 py-2 flex items-center text-xs uppercase font-bold leading-snug text-white hover:opacity-75"
             routerLink=""
           >
-            <i class="fab fa-facebook-square text-lg leading-lg text-white opacity-75"></i
-            ><span class="ml-2">Home</span>
+            <i class="fab fa-facebook-square text-lg leading-lg text-white opacity-75"></i>
+            <span class="ml-2">Home</span>
           </a>
         </li>
       </ul>
@@ -36,19 +36,18 @@
     <!-- Date Picker -->
     <div class="mb-4">
       <label class="block text-sm font-medium text-gray-600 mb-1">Select Date</label>
-     <input
-      id="yieldCurveDatePicker"
-      type="date"
-      [(ngModel)]="date"
-      (change)="onDateChange($event)"
-      class="border rounded-lg px-3 py-2 w-full focus:outline-none focus:ring-2 focus:ring-blue-500"
+      <input
+        id="yieldCurveDatePicker"
+        type="date"
+        [(ngModel)]="date"
+        (change)="onDateChange($event)"
+        class="border rounded-lg px-3 py-2 w-full focus:outline-none focus:ring-2 focus:ring-blue-500"
       />
     </div>
 
     <!-- Chart -->
     <canvas id="yieldChart" class="w-full h-80"></canvas>
   </div>
-  
 
   <!-- SP500 Card -->
   <div class="bg-white rounded-2xl shadow-lg p-6">
@@ -78,5 +77,29 @@
 
     <!-- Chart -->
     <canvas id="sp500Chart" class="w-full h-80"></canvas>
+
+    <!-- Volatility Controls -->
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mt-4">
+      <div>
+        <label class="block text-sm font-medium text-gray-600 mb-1">Volatility Window (days)</label>
+        <input
+          type="number"
+          min="1"
+          [value]="volatilityWindowSize"
+          (change)="onVolatilityWindowSizeChange($event)"
+          class="border rounded-lg px-3 py-2 w-full focus:outline-none focus:ring-2 focus:ring-green-500"
+        />
+      </div>
+      <div>
+        <label class="block text-sm font-medium text-gray-600 mb-1">Volatility Threshold</label>
+        <input
+          type="number"
+          step="0.1"
+          [value]="volatilityThreshold"
+          (change)="onVolatilityThresholdChange($event)"
+          class="border rounded-lg px-3 py-2 w-full focus:outline-none focus:ring-2 focus:ring-green-500"
+        />
+      </div>
+    </div>
   </div>
 </div>

--- a/WebUI/YieldView.web/src/app/yield-curve-chart/yield-curve-chart.component.ts
+++ b/WebUI/YieldView.web/src/app/yield-curve-chart/yield-curve-chart.component.ts
@@ -87,12 +87,6 @@ export class YieldCurveChartComponent implements OnInit {
   this.loadSp500Chart();
 }
 
-  onEpsChange(event: Event): void {
-  const target = event.target as HTMLInputElement;
-  this.eps = Number(target.value);
-  this.loadSp500Chart();
-}
-
   loadDataAndRenderChart(date: string) {
     this.yieldCurveService.getYieldCurve(this.country, date).subscribe(data => {
       const sortedData = data.sort(

--- a/WebUI/YieldView.web/src/app/yield-curve-chart/yield-curve-chart.component.ts
+++ b/WebUI/YieldView.web/src/app/yield-curve-chart/yield-curve-chart.component.ts
@@ -9,12 +9,10 @@ import { MatDatepickerModule } from '@angular/material/datepicker';
 import { MatInputModule } from '@angular/material/input';
 import { MatNativeDateModule } from '@angular/material/core';
 import { SP500Service } from '../services/sp500.service';
-import { SP500Price } from '../Modules/SP500Price';
 import { forkJoin } from 'rxjs';
 import { SP500PriceWithVolatility } from '../Modules/SP500PriceWithVolatility';
 
 Chart.register(...registerables);
-
 
 @Component({
   selector: 'app-yield-curve-chart',
@@ -151,7 +149,7 @@ export class YieldCurveChartComponent implements OnInit {
 
 loadSp500Chart() {
 forkJoin({
-  sp500:this.sp500Service.getPricesWithVolatility(this.sp500FromDate,this.sp500ToDate, this.volatilityWindowSize,this.eps),
+  sp500:this.sp500Service.getPricesWithVolatility(this.sp500FromDate,this.sp500ToDate, this.volatilityWindowSize),
   spreads:this.yieldCurveService.getYieldCurveSpread(this.sp500FromDate,this.sp500ToDate, this.country)
 })
 .subscribe(({sp500,spreads}) => {
@@ -160,12 +158,8 @@ forkJoin({
   const sp500Labels: string[] = sp500.map(d => d.date.split('T')[0]);
   const sp500Prices: number[] = sp500.map(d => d.close);
   const sp500Vols: number[] = sp500.map(d => d.volatility);
-   const sp500Data = sp500;
+  const sp500Data = sp500;
 
- console.log('SP500Data:',JSON.stringify(sp500Data));  
-  console.log('SP500 Volatilities:', sp500Vols);
-
-  // build dictionary
    const spreadMap = new Map(spreads.map(s => [s.date.split('T')[0], s.spread]));
    const spreadData: (number|null)[]  = sp500Labels.map(d => spreadMap.get(d) ?? null);
 
@@ -201,10 +195,7 @@ createSp500Chart(sp500Labels: string[], sp500Prices: number[], sp500Vols: number
         fill: false,
         tension: 2,
         spanGaps: true,
-        pointRadius: (ctx) => {
-          const i = ctx.dataIndex;
-          return sp500Data[i].isLocalShadowPoint ? 8 : 0; 
-        },   
+        pointRadius: 0,   
         pointHoverRadius: 4, 
         pointBorderWidth: 0, 
         yAxisID: 'y'

--- a/YieldView.API/Controllers/SP500Controller.cs
+++ b/YieldView.API/Controllers/SP500Controller.cs
@@ -33,11 +33,12 @@ public class SP500Controller(SP500DataProvider dataProvider) : ControllerBase
     GetHistoricalPricesWithVolatility(
         [FromQuery] DateTime from,
         [FromQuery] DateTime to,
-        [FromQuery] int dataInterval)
+        [FromQuery] int dataInterval,
+        [FromQuery] double eps)
   {
     try
     {
-      var results = await dataProvider.GetHistoricalPricesWithVolatilityAsync(from, to, dataInterval);
+      var results = await dataProvider.GetHistoricalPricesWithVolatilityAsync(from, to, dataInterval,eps);
 
       if (results == null || results.Count == 0)
       {

--- a/YieldView.API/Controllers/SP500Controller.cs
+++ b/YieldView.API/Controllers/SP500Controller.cs
@@ -8,49 +8,44 @@ namespace YieldView.API.Controllers;
 [ApiController]
 public class SP500Controller(SP500DataProvider dataProvider) : ControllerBase
 {
-  [HttpGet]
-  public async Task<ActionResult<IEnumerable<SP500Price>>> Get([FromQuery] DateTime? from, [FromQuery] DateTime? to)
-  {
-    if (from == null || to == null)
+    [HttpGet]
+    public async Task<ActionResult<IEnumerable<SP500Price>>> Get([FromQuery] DateTime? from, [FromQuery] DateTime? to)
     {
-      return BadRequest("Please provide both from and to dates.");
+        if (from == null || to == null)
+        {
+            return BadRequest("Please provide both from and to dates.");
+        }
+
+        var prices = await dataProvider.GetHistoricalPricesAsync(from.Value, to.Value);
+
+        if (prices.Count==0)
+        {
+            return NotFound("No prices found in the given date range.");
+        }
+
+        return Ok(prices);
     }
 
-    var prices = await dataProvider.GetHistoricalPricesAsync(from.Value, to.Value);
-
-    if (!prices.Any())
-    {
-      return NotFound("No prices found in the given date range.");
-    }
-
-    return Ok(prices);
-  }
-
-
-  //GET https://localhost:7031/api/sp500/volatility?from=2024-08-01&to=2025-08-01&dataInterval=20
-  [HttpGet("volatility")]
-  public async Task<ActionResult<IEnumerable<SP500PriceWithVolatility>>>
-    GetHistoricalPricesWithVolatility(
+    [HttpGet("volatility")]
+    public async Task<ActionResult<IEnumerable<SP500PriceWithVolatility>>> GetHistoricalPricesWithVolatility(
         [FromQuery] DateTime from,
         [FromQuery] DateTime to,
-        [FromQuery] int dataInterval,
-        [FromQuery] double eps)
-  {
-    try
+        [FromQuery] int dataInterval)
     {
-      var results = await dataProvider.GetHistoricalPricesWithVolatilityAsync(from, to, dataInterval,eps);
+        try
+        {
+            var results = await dataProvider.GetHistoricalPricesWithVolatilityAsync(from, to, dataInterval);
 
-      if (results == null || results.Count == 0)
-      {
-        return NotFound($"No volatility data between {from:yyyy-MM-dd} and {to:yyyy-MM-dd}.");
-      }
+            if (results == null || results.Count == 0)
+            {
+                return NotFound($"No volatility data between {from:yyyy-MM-dd} and {to:yyyy-MM-dd}.");
+            }
 
-      return Ok(results);
+            return Ok(results);
+        }
+        catch (ArgumentException ex)
+        {
+            return BadRequest(ex.Message);
+        }
     }
-    catch (ArgumentException ex)
-    {
-      return BadRequest(ex.Message);
-    }
-  }
-
 }

--- a/YieldView.API/Controllers/SP500Controller.cs
+++ b/YieldView.API/Controllers/SP500Controller.cs
@@ -25,4 +25,31 @@ public class SP500Controller(SP500DataProvider dataProvider) : ControllerBase
 
     return Ok(prices);
   }
+
+
+  //GET https://localhost:7031/api/sp500/volatility?from=2024-08-01&to=2025-08-01&dataInterval=20
+  [HttpGet("volatility")]
+  public async Task<ActionResult<IEnumerable<SP500PriceWithVolatility>>>
+    GetHistoricalPricesWithVolatility(
+        [FromQuery] DateTime from,
+        [FromQuery] DateTime to,
+        [FromQuery] int dataInterval)
+  {
+    try
+    {
+      var results = await dataProvider.GetHistoricalPricesWithVolatilityAsync(from, to, dataInterval);
+
+      if (results == null || results.Count == 0)
+      {
+        return NotFound($"No volatility data between {from:yyyy-MM-dd} and {to:yyyy-MM-dd}.");
+      }
+
+      return Ok(results);
+    }
+    catch (ArgumentException ex)
+    {
+      return BadRequest(ex.Message);
+    }
+  }
+
 }

--- a/YieldView.API/Models/SP500Price.cs
+++ b/YieldView.API/Models/SP500Price.cs
@@ -5,4 +5,5 @@ public class SP500Price
   public int Id { get; set; }
   public DateTime Date { get; set; }
   public double Close { get; set; }
+  public bool IsLocalShadowPoint { get; set; } = false;
 }

--- a/YieldView.API/Models/SP500Price.cs
+++ b/YieldView.API/Models/SP500Price.cs
@@ -4,5 +4,5 @@ public class SP500Price
 {
   public int Id { get; set; }
   public DateTime Date { get; set; }
-  public decimal Close { get; set; }
+  public double Close { get; set; }
 }

--- a/YieldView.API/Models/SP500PriceWithVolatility.cs
+++ b/YieldView.API/Models/SP500PriceWithVolatility.cs
@@ -1,9 +1,3 @@
 namespace YieldView.API.Models;
 
-public class SP500PriceWithVolatility
-{
-  public DateTime Date { get; set; }
-  public double Close { get; set; }
-  public double? Volatility { get; set; }
-  public bool IsLocalShadowPoint { get; set; } = false;
-}
+public record SP500PriceWithVolatility(DateTime Date, double Close, double? Volatility);

--- a/YieldView.API/Models/SP500PriceWithVolatility.cs
+++ b/YieldView.API/Models/SP500PriceWithVolatility.cs
@@ -1,0 +1,8 @@
+namespace YieldView.API.Models;
+
+public class SP500PriceWithVolatility
+{
+  public DateTime Date { get; set; }
+  public double Close { get; set; }
+  public double? Volatility { get; set; }
+}

--- a/YieldView.API/Models/SP500PriceWithVolatility.cs
+++ b/YieldView.API/Models/SP500PriceWithVolatility.cs
@@ -5,4 +5,5 @@ public class SP500PriceWithVolatility
   public DateTime Date { get; set; }
   public double Close { get; set; }
   public double? Volatility { get; set; }
+  public bool IsLocalShadowPoint { get; set; } = false;
 }

--- a/YieldView.API/Services/Contract/ISP500DataProvider.cs
+++ b/YieldView.API/Services/Contract/ISP500DataProvider.cs
@@ -10,8 +10,8 @@ public interface ISP500DataProvider
   /// </summary>  
   /// <param name="from">The start date of the time range.</param>  
   /// <param name="to">The end date of the time range.</param>  
-  /// <param name="dataInterval">The interval in days for the data points.</param>  
+  /// <param name="windowSize">The interval in days for the data points.</param>  
   /// <returns>A task that represents the asynchronous operation. The task result contains a list of S&P 500 prices with their associated volatility.</returns>  
   Task<List<SP500PriceWithVolatility>> GetHistoricalPricesWithVolatilityAsync(
-          DateTime from, DateTime to, int dataInterval = 20, double eps=0.1);
+          DateTime from, DateTime to, int windowSize = 20);
 }

--- a/YieldView.API/Services/Contract/ISP500DataProvider.cs
+++ b/YieldView.API/Services/Contract/ISP500DataProvider.cs
@@ -1,0 +1,17 @@
+using YieldView.API.Models;
+
+namespace YieldView.API.Services.Contract;
+
+public interface ISP500DataProvider
+{
+  /// <summary>  
+  /// Retrieves historical prices of the S&P 500 index along with their volatility  
+  /// for a specified time range and data interval.  
+  /// </summary>  
+  /// <param name="from">The start date of the time range.</param>  
+  /// <param name="to">The end date of the time range.</param>  
+  /// <param name="dataInterval">The interval in days for the data points.</param>  
+  /// <returns>A task that represents the asynchronous operation. The task result contains a list of S&P 500 prices with their associated volatility.</returns>  
+  Task<List<SP500PriceWithVolatility>> GetHistoricalPricesWithVolatilityAsync(
+          DateTime from, DateTime to, int dataInterval = 20);
+}

--- a/YieldView.API/Services/Contract/ISP500DataProvider.cs
+++ b/YieldView.API/Services/Contract/ISP500DataProvider.cs
@@ -13,5 +13,5 @@ public interface ISP500DataProvider
   /// <param name="dataInterval">The interval in days for the data points.</param>  
   /// <returns>A task that represents the asynchronous operation. The task result contains a list of S&P 500 prices with their associated volatility.</returns>  
   Task<List<SP500PriceWithVolatility>> GetHistoricalPricesWithVolatilityAsync(
-          DateTime from, DateTime to, int dataInterval = 20);
+          DateTime from, DateTime to, int dataInterval = 20, double eps=0.1);
 }

--- a/YieldView.API/Services/Contract/IYieldSpreadProvider.cs
+++ b/YieldView.API/Services/Contract/IYieldSpreadProvider.cs
@@ -1,0 +1,15 @@
+using YieldView.API.Models;
+
+namespace YieldView.API.Services.Contract;
+
+public interface IYieldSpreadProvider
+{
+    /// <summary>  
+    /// Retrieves yield spreads for a specified country and time period.  
+    /// </summary>  
+    /// <param name="from">The start date of the time range.</param>  
+    /// <param name="to">The end date of the time range.</param>  
+    /// <param name="country">The country for which yield spreads are requested.</param>  
+    /// <returns>A task that represents the asynchronous operation. The task result contains a list of yield spreads.</returns>  
+    Task<List<YieldSpread>> GetYieldSpreadsAsync(DateTime from, DateTime to, string country);
+}

--- a/YieldView.API/Services/Impl/SP500DataProvider.cs
+++ b/YieldView.API/Services/Impl/SP500DataProvider.cs
@@ -1,10 +1,11 @@
 using Microsoft.EntityFrameworkCore;
 using YieldView.API.Data;
 using YieldView.API.Models;
+using YieldView.API.Services.Contract;
 
 namespace YieldView.API.Services.Impl;
 
-public class SP500DataProvider(IServiceScopeFactory scopeFactory)
+public class SP500DataProvider(IServiceScopeFactory scopeFactory): ISP500DataProvider
 {
   private readonly IServiceScopeFactory scopeFactory = scopeFactory;
 
@@ -17,6 +18,60 @@ public class SP500DataProvider(IServiceScopeFactory scopeFactory)
                           .Where(p => p.Date >= from && p.Date <= to)
                           .OrderBy(p => p.Date)
                           .ToListAsync();
+  }
+
+    /// <inheritdoc />  
+    public async Task<List<SP500PriceWithVolatility>> GetHistoricalPricesWithVolatilityAsync(DateTime from, DateTime to, int dataInterval)
+    {
+        using var scope = scopeFactory.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<YieldDbContext>();
+
+        var prices = await dbContext.SP500Prices
+            .Where(p => p.Date >= from && p.Date <= to)
+            .OrderBy(p => p.Date)
+            .ToListAsync();
+
+        List<double> returns = GetReturns(prices);
+
+        var result = new List<SP500PriceWithVolatility>();
+        for (int i = 0; i < prices.Count; i++)
+        {
+            var volatility = CalculateVolatility(returns, i, dataInterval);
+
+            result.Add(new SP500PriceWithVolatility
+            {
+                Date = prices[i].Date,
+                Close = prices[i].Close,
+                Volatility = volatility
+            });
+        }
+
+        return result;
+    }
+
+
+
+  private static double? CalculateVolatility(List<double> returns, int currentIndex, int dataInterval)
+  {
+    if (currentIndex < dataInterval)
+      return null;
+
+    var windowReturns = returns.Skip(currentIndex - dataInterval).Take(dataInterval).ToList();
+    double mean = windowReturns.Average();
+    double variance = windowReturns.Average(r => Math.Pow(r - mean, 2));
+    return Math.Sqrt(variance);
+  }
+
+  private static List<double> GetReturns(List<SP500Price> prices)
+  {
+    var returns = new List<double>();
+    for (int i = 1; i < prices.Count; i++)
+    {
+      double ret = Math.Log(prices[i].Close / prices[i - 1].Close);
+      returns.Add(ret);
+    }
+
+    return returns;
   }
 }
 

--- a/YieldView.API/Services/Impl/SP500Service.cs
+++ b/YieldView.API/Services/Impl/SP500Service.cs
@@ -7,57 +7,62 @@ using YieldView.API.Models;
 namespace YieldView.API.Services.Impl;
 
 public class SP500Service(HttpClient httpClient, IOptions<YieldCurveSourcesConfig> options, IServiceScopeFactory scopeFactory)
-  : BackgroundService
+ : BackgroundService
 {
-  private readonly YieldCurveSourcesConfig sources = options.Value;
+    private readonly YieldCurveSourcesConfig sources = options.Value;
 
-  protected override async Task ExecuteAsync(CancellationToken cancellationToken)
-  {
-    using var scope = scopeFactory.CreateScope();
-    var dbContext = scope.ServiceProvider.GetRequiredService<YieldDbContext>();
-
-    if (!sources.TryGetValue("SP500", out var sp500Source))
+    protected override async Task ExecuteAsync(CancellationToken cancellationToken)
     {
-      return;
-    }
+        using var scope = scopeFactory.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<YieldDbContext>();
 
-    var fetchInterval = DataFetchHelper.GetDelayForInterval(sp500Source.FetchInterval);
-
-    while (!cancellationToken.IsCancellationRequested)
-    {
-      dbContext.SP500Prices.RemoveRange(dbContext.SP500Prices);
-      await dbContext.SaveChangesAsync(cancellationToken);
-
-      var startDate = new DateTime(sp500Source.Years[0], 1, 1).ToString("yyyyMMdd");
-      var endDate = DateTime.Today.ToString("yyyyMMdd");
-
-      var url = $"{sp500Source.BaseUrl}&d1={startDate}&d2={endDate}";
-
-      var csv = await httpClient.GetStringAsync(url, cancellationToken);
-
-      var lines = csv.Split("\n").Skip(1);
-
-      foreach (var line in lines)
-      {
-        if (string.IsNullOrWhiteSpace(line)) continue;
-
-        var parts = line.Split(',');
-        if (DateTime.TryParse(parts[0], out var date) &&
-            decimal.TryParse(parts[4], NumberStyles.Any, CultureInfo.InvariantCulture, out var close))
+        if (!sources.TryGetValue("SP500", out var sp500Source))
         {
-          dbContext.SP500Prices.Add(new SP500Price
-          {
-            Date = date,
-            Close = close
-          });
+            return;
         }
-      }
 
-      await dbContext.SaveChangesAsync(cancellationToken);
-      Console.WriteLine("finished loading sp500 data!");
+        var fetchInterval = DataFetchHelper.GetDelayForInterval(sp500Source.FetchInterval);
 
-      await Task.Delay(fetchInterval, cancellationToken);
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            dbContext.SP500Prices.RemoveRange(dbContext.SP500Prices);
+            await dbContext.SaveChangesAsync(cancellationToken);
+
+            var startDate = new DateTime(sp500Source.Years[0], 1, 1).ToString("yyyyMMdd");
+            var endDate = DateTime.Today.ToString("yyyyMMdd");
+
+            var url = $"{sp500Source.BaseUrl}&d1={startDate}&d2={endDate}";
+
+            var csv = await httpClient.GetStringAsync(url, cancellationToken);
+
+            var lines = csv.Split("\n").Skip(1);
+
+            foreach (var line in lines)
+            {
+                if (string.IsNullOrWhiteSpace(line))
+                {
+                    continue;
+                }
+
+                var parts = line.Split(',');
+
+                    // Todo: Maybe using decimal is better????
+                if (DateTime.TryParse(parts[0], out var date) &&
+                    double.TryParse(parts[4], NumberStyles.Any, CultureInfo.InvariantCulture, out var close))
+                {
+                    dbContext.SP500Prices.Add(new SP500Price
+                    {
+                        Date = date,
+                        Close = close   
+                    });
+                }
+            }
+
+            await dbContext.SaveChangesAsync(cancellationToken);
+            Console.WriteLine("finished loading sp500 data!");
+
+            await Task.Delay(fetchInterval, cancellationToken);
+        }
     }
-  }
 }
 

--- a/YieldView.API/Services/Impl/YieldSpreadProvider.cs
+++ b/YieldView.API/Services/Impl/YieldSpreadProvider.cs
@@ -1,7 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using YieldView.API.Data;
 using YieldView.API.Models;
-using static System.Runtime.InteropServices.JavaScript.JSType;
 
 namespace YieldView.API.Services.Impl;
 
@@ -34,4 +33,67 @@ public class YieldSpreadProvider(IServiceScopeFactory scopeFactory)
 
     return spreads;
   }
+
+  /// <summary>
+  /// Votality
+  /// </summary>
+  public async Task<List<SP500PriceWithVolatility>> GetHistoricalPricesWithVolatilityAsync(
+      DateTime from, DateTime to, int dataInterval = 20)
+  {
+    using var scope = scopeFactory.CreateScope();
+    var dbContext = scope.ServiceProvider.GetRequiredService<YieldDbContext>();
+
+    var prices = await dbContext.SP500Prices
+        .Where(p => p.Date >= from && p.Date <= to)
+        .OrderBy(p => p.Date)
+        .ToListAsync();
+
+    List<double> returns = GetReturns(prices);
+
+    var result = new List<SP500PriceWithVolatility>();
+    for (int i = 0; i < prices.Count; i++)
+    {
+      double? volatility = null;
+
+      // here: this should be optimized: just take everything before until windowsize
+      if (i >= dataInterval)
+      {
+        var windowReturns = returns.Skip(i - dataInterval).Take(dataInterval).ToList();
+        double mean = windowReturns.Average();
+        double variance = windowReturns.Average(r => Math.Pow(r - mean, 2));
+        volatility = Math.Sqrt(variance);
+      }
+
+      result.Add(new SP500PriceWithVolatility
+      {
+        Date = prices[i].Date,
+        Close = prices[i].Close,
+        Volatility = volatility
+      });
+    }
+
+    return result;
+  }
+
+  // how are returns computed? Really a log?
+  private static List<double> GetReturns(List<SP500Price> prices)
+  {
+    var returns = new List<double>();
+    for (int i = 1; i < prices.Count; i++)
+    {
+      double ret = Math.Log(prices[i].Close / prices[i - 1].Close);
+      returns.Add(ret);
+    }
+
+    return returns;
+  }
+
+  //embedd there the other model
+  public class SP500PriceWithVolatility
+  {
+    public DateTime Date { get; set; }
+    public double Close { get; set; }
+    public double? Volatility { get; set; }
+  }
+
 }

--- a/YieldView.API/Services/Impl/YieldSpreadProvider.cs
+++ b/YieldView.API/Services/Impl/YieldSpreadProvider.cs
@@ -1,21 +1,19 @@
 using Microsoft.EntityFrameworkCore;
 using YieldView.API.Data;
 using YieldView.API.Models;
+using YieldView.API.Services.Contract;
 
 namespace YieldView.API.Services.Impl;
 
-public class YieldSpreadProvider(IServiceScopeFactory scopeFactory)
+public sealed class YieldSpreadProvider(IServiceScopeFactory scopeFactory) : IYieldSpreadProvider
 {
-  public async Task<List<YieldSpread>> GetYieldSpreadsAsync(DateTime from, DateTime to, string country)
-  {
-    using var scope = scopeFactory.CreateScope();
-    var dbContext = scope.ServiceProvider.GetRequiredService<YieldDbContext>();
-    IQueryable<YieldCurvePoint> query = country.ToUpper() switch
+    public async Task<List<YieldSpread>> GetYieldSpreadsAsync(DateTime from, DateTime to, string country)
     {
-      "US" => dbContext.USYieldCurvePoints,
-      _ => throw new ArgumentException($"Unsupported country: {country}"),
-    };
-    var spreads = await query
+        using var scope = scopeFactory.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<YieldDbContext>();
+        var query = GetYieldCurvePointsByCountry(country, dbContext);
+
+        var spreads = await query
             .Where(yc => (yc.Maturity == "10Y" || yc.Maturity == "6M")
                          && yc.Date.Date >= from.Date
                          && yc.Date.Date <= to.Date)
@@ -23,77 +21,23 @@ public class YieldSpreadProvider(IServiceScopeFactory scopeFactory)
             .OrderBy(g => g.Key)
             .Select(g => new YieldSpread
             {
-              Date = g.Key,
-              TenYear = g.FirstOrDefault(x => x.Maturity == "10Y")!.Yield,
-              SixMonth = g.FirstOrDefault(x => x.Maturity == "6M")!.Yield,
-              Spread = g.FirstOrDefault(x => x.Maturity == "10Y")!.Yield -
+                Date = g.Key,
+                TenYear = g.FirstOrDefault(x => x.Maturity == "10Y")!.Yield,
+                SixMonth = g.FirstOrDefault(x => x.Maturity == "6M")!.Yield,
+                Spread = g.FirstOrDefault(x => x.Maturity == "10Y")!.Yield -
                          g.FirstOrDefault(x => x.Maturity == "6M")!.Yield
             })
             .ToListAsync();
 
-    return spreads;
-  }
-
-  /// <summary>
-  /// Votality
-  /// </summary>
-  public async Task<List<SP500PriceWithVolatility>> GetHistoricalPricesWithVolatilityAsync(
-      DateTime from, DateTime to, int dataInterval = 20)
-  {
-    using var scope = scopeFactory.CreateScope();
-    var dbContext = scope.ServiceProvider.GetRequiredService<YieldDbContext>();
-
-    var prices = await dbContext.SP500Prices
-        .Where(p => p.Date >= from && p.Date <= to)
-        .OrderBy(p => p.Date)
-        .ToListAsync();
-
-    List<double> returns = GetReturns(prices);
-
-    var result = new List<SP500PriceWithVolatility>();
-    for (int i = 0; i < prices.Count; i++)
-    {
-      double? volatility = null;
-
-      // here: this should be optimized: just take everything before until windowsize
-      if (i >= dataInterval)
-      {
-        var windowReturns = returns.Skip(i - dataInterval).Take(dataInterval).ToList();
-        double mean = windowReturns.Average();
-        double variance = windowReturns.Average(r => Math.Pow(r - mean, 2));
-        volatility = Math.Sqrt(variance);
-      }
-
-      result.Add(new SP500PriceWithVolatility
-      {
-        Date = prices[i].Date,
-        Close = prices[i].Close,
-        Volatility = volatility
-      });
+        return spreads;
     }
 
-    return result;
-  }
-
-  // how are returns computed? Really a log?
-  private static List<double> GetReturns(List<SP500Price> prices)
-  {
-    var returns = new List<double>();
-    for (int i = 1; i < prices.Count; i++)
+    private static DbSet<YieldCurvePoint> GetYieldCurvePointsByCountry(string country, YieldDbContext dbContext)
     {
-      double ret = Math.Log(prices[i].Close / prices[i - 1].Close);
-      returns.Add(ret);
+        return country.ToUpper() switch
+        {
+            "US" => dbContext.USYieldCurvePoints,
+            _ => throw new ArgumentException($"Unsupported country: {country}"),
+        };
     }
-
-    return returns;
-  }
-
-  //embedd there the other model
-  public class SP500PriceWithVolatility
-  {
-    public DateTime Date { get; set; }
-    public double Close { get; set; }
-    public double? Volatility { get; set; }
-  }
-
 }


### PR DESCRIPTION
## Summary of Changes in PR “Volatility”

###  Backend Enhancements
- Added endpoint `GET /api/sp500/volatility?from={}&to={}&dataInterval={}` that returns SP500 prices with computed volatility over the specified data interval.  
- Introduced model `SP500PriceWithVolatility` to carry date, close price, and volatility.  
- Backend service updated to compute volatility and deliver results; 

###  Frontend Improvements
- New interface `SP500PriceWithVolatility` added; frontend now calls the new volatility endpoint.  
- In `YieldCurveChartComponent` added number inputs for **volatility window** and **volatility threshold**.  
- SP500 chart updated: segment coloring based on threshold, tooltip displays volatility value.  
- UI layout tweaks to include the new controls around the SP500 chart.


###  Verification Steps
- Test default view: chart displays SP500 closing prices + volatility segments.  
- Change window/threshold controls → chart updates correctly.  
- Tooltip shows volatility next to close price.  
- Edge cases: small intervals, missing data, very high threshold.
